### PR TITLE
update to use Parser.acorn

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -1,5 +1,6 @@
 var driver = require("./driver.js");
 require("./tests-jsx.js");
+require("./tests-misc.js");
 
 function group(name) {
   if (typeof console === "object" && console.group) {

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -1,0 +1,50 @@
+"use strict";
+
+if (typeof exports !== "undefined") {
+  var assert = require("assert");
+  var acorn = require("acorn");
+  var jsx = require("..");
+  var testAssert = require("./driver.js").testAssert;
+}
+
+testAssert("// the enhanced Parser instance should have a static property 'acornJsx'.", function() {
+  const JsxParser = acorn.Parser.extend(jsx());
+  assert(JsxParser.acornJsx);
+});
+
+testAssert("// 'acornJsx' should be the same instance for the same acorn.", function() {
+  const JsxParser1 = acorn.Parser.extend(jsx());
+  const JsxParser2 = acorn.Parser.extend(jsx());
+  assert.strictEqual(JsxParser1.acornJsx, JsxParser2.acornJsx);
+});
+
+testAssert("// the static property 'acornJsx' should have two properties.", function() {
+  const JsxParser = acorn.Parser.extend(jsx());
+  assert(JsxParser.acornJsx.tokTypes, "should have 'tokTypes'.");
+  assert(JsxParser.acornJsx.tokContexts, "should have 'tokContexts'.");
+});
+
+testAssert("// 'acornJsx.tokTypes' should be used.", function() {
+  const JsxParser = acorn.Parser.extend(jsx());
+  const code = '<a>{/* foo */}</a>';
+  const expectedTokTypes = [
+    JsxParser.acornJsx.tokTypes.jsxTagStart,
+    JsxParser.acornJsx.tokTypes.jsxName,
+    JsxParser.acornJsx.tokTypes.jsxTagEnd,
+    acorn.tokTypes.braceL,
+    acorn.tokTypes.braceR,
+    JsxParser.acornJsx.tokTypes.jsxTagStart,
+    acorn.tokTypes.slash,
+    JsxParser.acornJsx.tokTypes.jsxName,
+    JsxParser.acornJsx.tokTypes.jsxTagEnd,
+    acorn.tokTypes.eof
+  ]
+  const actualTokens = []
+
+  JsxParser.parse(code, {onToken: actualTokens})
+
+  assert.strictEqual(actualTokens.length, expectedTokTypes.length);
+  for (let i = 0; i < actualTokens.length; ++i) {
+    assert.strictEqual(actualTokens[i].type, expectedTokTypes[i]);
+  }
+});


### PR DESCRIPTION
This PR updates `acorn-jsx` to use `Parser.acorn` property that `acorn@7.1.0` added. This is to solve the problem https://github.com/acornjs/acorn/pull/870 describes.

The `require("acorn-jsx").tokTypes` property is as-is, the JSX token types for the `acorn` of the peer dependency.

This PR adds a static property `acornJsx` to the enhanced `Parser` class.

```js
const acorn = require("acorn")
const acornJsx = require("acorn-jsx")
const JsxParser = acorn.Parser.extend(acornJsx())

console.log(JsxParser.acornJsx) //→ an object { tokContexts: {...}, tokTypes: {...} }
```

That static property exposes the actual JSX token types to other plugins that want to modify JSX tokens. The `JsxParser.acornJsx` and `require("acorn-jsx").tokTypes` are the same instance in most situation. But those can be different in the special situation https://github.com/acornjs/acorn/pull/870 describes.

[Espree will use the `JsxParser.acornJsx`](https://github.com/eslint/espree/pull/426/files?w=1) to modify tokens.