### PR TITLE
chore: Make support for acorn 8 explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ node_js:
   - '8'
   - '10'
   - '12'
+  - '14'
 env:
   - ACORN_VERSION=6
   - ACORN_VERSION=7
+  - ACORN_VERSION=8
 
 install:
   - npm install -D acorn@$ACORN_VERSION

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "test": "node test/run.js"
   },
   "peerDependencies": {
-    "acorn": "^6.0.0 || ^7.0.0"
+    "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "acorn": "^7.0.0"
+    "acorn": "^8.0.1"
   }
 }

--- a/test/driver.js
+++ b/test/driver.js
@@ -17,7 +17,7 @@ exports.runTests = function(config, callback) {
     var test = tests[i];
     if (config.filter && !config.filter(test)) continue;
     try {
-      var testOpts = test.options || {locations: true};
+      var testOpts = Object.assign({ecmaVersion: 11}, test.options || {locations: true});
       var expected = {};
       if (expected.onComment = testOpts.onComment) {
         testOpts.onComment = []

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -41,7 +41,7 @@ testAssert("// 'acornJsx.tokTypes' should be used.", function() {
   ]
   const actualTokens = []
 
-  JsxParser.parse(code, {onToken: actualTokens})
+  JsxParser.parse(code, {ecmaVersion: 11, onToken: actualTokens})
 
   assert.strictEqual(actualTokens.length, expectedTokTypes.length);
   for (let i = 0; i < actualTokens.length; ++i) {


### PR DESCRIPTION
## Description

acorn-jsx works fine with acorn 8, but acorn 8 compatibility isn't listed in its peer dependencies yet, so package management tools complain on install. 

This PR makes the fact acorn-jsx works OK with acorn 8 explicit. Fixes #118 

## Changes

- adds acorn 8 to the peer dependencies (& ups the devDependency to ^8.0.1).
- updates the .travis.yml ci config to also check against acorn 8 (and to run on node 14)
- in the tests explicitly passes the ecmaVersion (as 11) in the options in cases it wasn't set explicitly; the [acorn 8.0.0 release notes](https://github.com/acornjs/acorn/releases/tag/8.0.0) mention this as the only breaking change. Setting it explicitly (1) prevents a warning in the test output and (2) likely prevents the tests from failing in the future.


## Test plan

- automated non-regression tests pass
- green CI
