### PR TITLE
Add transformEntities option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ acorn.Parser.extend(jsx({ allowNamespaces: false }))
 
 Note that by default `allowNamespaces` is enabled for spec compliancy.
 
+By default, HTML entities are parsed and transformed within strings. To disable this functionality (and treat HTML entities as plain text), you can provide `transformEntities: false` as an option:
+
+```javascript
+acorn.Parser.extend(jsx({ transformEntities: false }))
+```
+
 ## License
 
 This plugin is issued under the [MIT license](./LICENSE).

--- a/test/tests-jsx.js
+++ b/test/tests-jsx.js
@@ -4634,6 +4634,59 @@ test('<A>foo&gt;</A>', {
     }
   ]
 });
+test('<A>foo&gt;</A>', {
+  "type": "Program",
+  "start": 0,
+  "end": 14,
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 14,
+      "expression": {
+        "type": "JSXElement",
+        "start": 0,
+        "end": 14,
+        "openingElement": {
+          "type": "JSXOpeningElement",
+          "start": 0,
+          "end": 3,
+          "attributes": [],
+          "name": {
+            "type": "JSXIdentifier",
+            "start": 1,
+            "end": 2,
+            "name": "A"
+          },
+          "selfClosing": false
+        },
+        "closingElement": {
+          "type": "JSXClosingElement",
+          "start": 10,
+          "end": 14,
+          "name": {
+            "type": "JSXIdentifier",
+            "start": 12,
+            "end": 13,
+            "name": "A"
+          }
+        },
+        "children": [
+          {
+            "type": "JSXText",
+            "start": 3,
+            "end": 10,
+            "value": "foo&gt;",
+            "raw": "foo&gt;"
+          }
+        ]
+      }
+    }
+  ]
+}, {
+}, {
+  transformEntities: false
+});
 test('function*it(){yield <a></a>}', {
   "type": "Program",
   "start": 0,


### PR DESCRIPTION
Ref #105

A bit of context is in https://github.com/acornjs/acorn-jsx/issues/105#issuecomment-742754881 but ultimately this parser should not be transforming HTML entities for the user - that's up to the compiler or the user agent.

While I personally believe this functionality should be stripped from this package entirely and downstream consumers should be the ones to make that decision, I figured that'd be less palatable than keeping things backwards compatible.

Therefore, this PR introduces the option `transformEntities` which is enabled by default that will handle HTML entities and transform them automatically - the current functionality. Passing `false` disables this and leaves HTML entities untouched.

This is imperative for proper parsing for many non-React frameworks.

---

A note about the implementation: to keep things performant, I (ab)use an explicit `case` fallthrough as a makeshift `goto`, avoiding duplicated code or more string fetches, etc. The branch is inevitable, but thankfully only occurs if `&` is detected (which is much less often than if it were to be put into `default` to avoid the fallthrough, for example). This was the best balance between code readability and performance in my opinion.