### PR TITLE
Rename AcornJSXOptions to Options in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { Parser } from 'acorn' 
 
-declare const jsx: (options?: jsx.AcornJSXOptions) => (BaseParser: typeof Parser) => typeof Parser;
+declare const jsx: (options?: jsx.Options) => (BaseParser: typeof Parser) => typeof Parser;
 
 declare namespace jsx {
   interface Options {


### PR DESCRIPTION
There was an incorrect naming in index.d.ts

fix [#123](https://github.com/acornjs/acorn-jsx/issues/123)