### PR TITLE
Improve typings: ESM, `AcornJsxParser` class and `tokTypes` const

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,15 +8,22 @@ export interface Options {
 }
 
 export const tokTypes: {
-    jsxName: acorn.TokenType,
-    jsxText: acorn.TokenType,
-    jsxTagEnd: acorn.TokenType,
-    jsxTagStart: acorn.TokenType
+  jsxName: acorn.TokenType,
+  jsxText: acorn.TokenType,
+  jsxTagEnd: acorn.TokenType,
+  jsxTagStart: acorn.TokenType
 } & typeof acorn.tokTypes;
+
+export const tokContexts: {
+  tc_oTag: acorn.TokContext,
+  tc_cTag: acorn.TokContext,
+  tc_expr: acorn.TokContext
+};
 
 export class AcornJsxParser extends acorn.Parser {
   static readonly acornJsx: {
-    tokTypes: typeof tokTypes
+    tokTypes: typeof tokTypes;
+    tokContexts: typeof tokContexts
   };
 
   jsx_readString(quote: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,5 +59,4 @@ export interface IAcornJsxParser extends acorn.Parser {
   jsx_parseElement(): acorn.Node;
 }
 
-export as namespace jsx;
 export default jsx;

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,23 @@ export class AcornJsxParser extends acorn.Parser {
     tokContexts: typeof tokContexts
   };
 
+  jsx_readToken(): string;
+  jsx_readNewLine(normalizeCRLF: boolean): void;
   jsx_readString(quote: number): void;
+  jsx_readEntity(): string;
+  jsx_readWord(): void;
+  jsx_parseIdentifier(): acorn.Node;
+  jsx_parseNamespacedName(): acorn.Node;
+  jsx_parseElementName(): acorn.Node | string;
+  jsx_parseAttributeValue(): acorn.Node;
+  jsx_parseEmptyExpression(): acorn.Node;
+  jsx_parseExpressionContainer(): acorn.Node;
+  jsx_parseAttribute(): acorn.Node;
+  jsx_parseOpeningElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
+  jsx_parseClosingElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
+  jsx_parseElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
+  jsx_parseText(): acorn.Node;
+  jsx_parseElement(): acorn.Node;
 }
 
 export as namespace jsx;

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,12 +27,10 @@ declare namespace jsx {
     tc_expr: acorn.TokContext
   }
 
-  type P = typeof acorn.Parser;
-
   // We pick (statics) from acorn rather than plain extending to avoid complaint
   //   about base constructors needing the same return type (i.e., we return
   //   `AcornJsxParser` here)
-  interface AcornJsxParserCtor extends Pick<P, keyof P> {
+  interface AcornJsxParserCtor extends Pick<typeof acorn.Parser, keyof typeof acorn.Parser> {
     readonly acornJsx: {
       tokTypes: TokTypes;
       tokContexts: TokContexts

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,14 +26,6 @@ export class AcornJsxParser extends acorn.Parser {
     tokContexts: typeof tokContexts
   };
 
-  pos: number;
-  start: number;
-  input: string;
-  lineStart: number;
-  type: acorn.TokenType;
-  exprAllowed: boolean;
-  context: acorn.TokContext[];
-
   jsx_readToken(): string;
   jsx_readNewLine(normalizeCRLF: boolean): void;
   jsx_readString(quote: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,14 @@ export class AcornJsxParser extends acorn.Parser {
     tokContexts: typeof tokContexts
   };
 
+  pos: number;
+  start: number;
+  input: string;
+  lineStart: number;
+  type: acorn.TokenType;
+  exprAllowed: boolean;
+  context: acorn.TokContext[];
+
   jsx_readToken(): string;
   jsx_readNewLine(normalizeCRLF: boolean): void;
   jsx_readString(quote: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,46 +2,46 @@ import * as acorn from 'acorn';
 
 declare const jsx: {
   tokTypes: typeof acorn.tokTypes;
-  (options?: jsx.Options): (BaseParser: typeof acorn.Parser) => jsx.AcornJsxParser
+  (options?: jsx.Options): (BaseParser: typeof acorn.Parser) => jsx.AcornJsxParserCtor
 }
 
 declare namespace jsx {
 
   type tokTypes = typeof acorn.tokTypes;
 
-  export interface TokTypes extends tokTypes {
+  interface TokTypes extends tokTypes {
     jsxName: acorn.TokenType,
     jsxText: acorn.TokenType,
     jsxTagEnd: acorn.TokenType,
     jsxTagStart: acorn.TokenType
   }
 
-  export interface Options {
+  interface Options {
     allowNamespacedObjects?: boolean;
     allowNamespaces?: boolean;
   }
 
-  export type TokContexts = {
+  interface TokContexts {
     tc_oTag: acorn.TokContext,
     tc_cTag: acorn.TokContext,
     tc_expr: acorn.TokContext
-  };
+  }
 
   type P = typeof acorn.Parser;
 
   // We pick (statics) from acorn rather than plain extending to avoid complaint
   //   about base constructors needing the same return type (i.e., we return
-  //   `IAcornJsxParser` here)
-  export interface AcornJsxParser extends Pick<P, keyof P> {
+  //   `AcornJsxParser` here)
+  interface AcornJsxParserCtor extends Pick<P, keyof P> {
     readonly acornJsx: {
       tokTypes: TokTypes;
       tokContexts: TokContexts
     };
 
-    new (options: acorn.Options, input: string, startPos?: number): IAcornJsxParser;
+    new (options: acorn.Options, input: string, startPos?: number): AcornJsxParser;
   }
 
-  export interface IAcornJsxParser extends acorn.Parser {
+  interface AcornJsxParser extends acorn.Parser {
     jsx_readToken(): string;
     jsx_readNewLine(normalizeCRLF: boolean): void;
     jsx_readString(quote: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,11 @@ declare const jsx: {
   (options?: jsx.Options): (BaseParser: typeof acorn.Parser) => jsx.AcornJsxParserCtor
 }
 
+type AcornTokTypes = typeof acorn.tokTypes;
+
 declare namespace jsx {
 
-  type tokTypes = typeof acorn.tokTypes;
-
-  interface TokTypes extends tokTypes {
+  interface TokTypes extends AcornTokTypes {
     jsxName: acorn.TokenType,
     jsxText: acorn.TokenType,
     jsxTagEnd: acorn.TokenType,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import acorn from 'acorn';
+import * as acorn from 'acorn';
 
 export const jsx: (options?: jsx.Options) => (BaseParser: typeof acorn.Parser) => typeof AcornJsxParser
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export const tokTypes: {
   jsxTagStart: acorn.TokenType
 } & typeof acorn.tokTypes;
 
-export const tokContexts: {
+export type TokContexts = {
   tc_oTag: acorn.TokContext,
   tc_cTag: acorn.TokContext,
   tc_expr: acorn.TokContext
@@ -23,7 +23,7 @@ export const tokContexts: {
 export class AcornJsxParser extends acorn.Parser {
   static readonly acornJsx: {
     tokTypes: typeof tokTypes;
-    tokContexts: typeof tokContexts
+    tokContexts: TokContexts
   };
 
   jsx_readToken(): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,62 +1,65 @@
 import * as acorn from 'acorn';
 
-type tokTypes = typeof acorn.tokTypes;
-
-export interface Options {
-  allowNamespacedObjects?: boolean;
-  allowNamespaces?: boolean;
-}
-
-export interface TokTypes extends tokTypes {
-  jsxName: acorn.TokenType,
-  jsxText: acorn.TokenType,
-  jsxTagEnd: acorn.TokenType,
-  jsxTagStart: acorn.TokenType
-}
-
 declare const jsx: {
-  tokTypes: TokTypes;
-  (options?: acorn.Options): (BaseParser: typeof acorn.Parser) => AcornJsxParser
+  tokTypes: typeof acorn.tokTypes;
+  (options?: jsx.Options): (BaseParser: typeof acorn.Parser) => jsx.AcornJsxParser
 }
 
-export type TokContexts = {
-  tc_oTag: acorn.TokContext,
-  tc_cTag: acorn.TokContext,
-  tc_expr: acorn.TokContext
-};
+declare namespace jsx {
 
-type P = typeof acorn.Parser;
+  type tokTypes = typeof acorn.tokTypes;
 
-// We pick (statics) from acorn rather than plain extending to avoid complaint
-//   about base constructors needing the same return type (i.e., we return
-//   `IAcornJsxParser` here)
-export interface AcornJsxParser extends Pick<P, keyof P> {
-  readonly acornJsx: {
-    tokTypes: TokTypes;
-    tokContexts: TokContexts
+  export interface TokTypes extends tokTypes {
+    jsxName: acorn.TokenType,
+    jsxText: acorn.TokenType,
+    jsxTagEnd: acorn.TokenType,
+    jsxTagStart: acorn.TokenType
+  }
+
+  export interface Options {
+    allowNamespacedObjects?: boolean;
+    allowNamespaces?: boolean;
+  }
+
+  export type TokContexts = {
+    tc_oTag: acorn.TokContext,
+    tc_cTag: acorn.TokContext,
+    tc_expr: acorn.TokContext
   };
 
-  new (options: acorn.Options, input: string, startPos?: number): IAcornJsxParser;
+  type P = typeof acorn.Parser;
+
+  // We pick (statics) from acorn rather than plain extending to avoid complaint
+  //   about base constructors needing the same return type (i.e., we return
+  //   `IAcornJsxParser` here)
+  export interface AcornJsxParser extends Pick<P, keyof P> {
+    readonly acornJsx: {
+      tokTypes: TokTypes;
+      tokContexts: TokContexts
+    };
+
+    new (options: acorn.Options, input: string, startPos?: number): IAcornJsxParser;
+  }
+
+  export interface IAcornJsxParser extends acorn.Parser {
+    jsx_readToken(): string;
+    jsx_readNewLine(normalizeCRLF: boolean): void;
+    jsx_readString(quote: number): void;
+    jsx_readEntity(): string;
+    jsx_readWord(): void;
+    jsx_parseIdentifier(): acorn.Node;
+    jsx_parseNamespacedName(): acorn.Node;
+    jsx_parseElementName(): acorn.Node | string;
+    jsx_parseAttributeValue(): acorn.Node;
+    jsx_parseEmptyExpression(): acorn.Node;
+    jsx_parseExpressionContainer(): acorn.Node;
+    jsx_parseAttribute(): acorn.Node;
+    jsx_parseOpeningElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
+    jsx_parseClosingElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
+    jsx_parseElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
+    jsx_parseText(): acorn.Node;
+    jsx_parseElement(): acorn.Node;
+  }
 }
 
-export interface IAcornJsxParser extends acorn.Parser {
-  jsx_readToken(): string;
-  jsx_readNewLine(normalizeCRLF: boolean): void;
-  jsx_readString(quote: number): void;
-  jsx_readEntity(): string;
-  jsx_readWord(): void;
-  jsx_parseIdentifier(): acorn.Node;
-  jsx_parseNamespacedName(): acorn.Node;
-  jsx_parseElementName(): acorn.Node | string;
-  jsx_parseAttributeValue(): acorn.Node;
-  jsx_parseEmptyExpression(): acorn.Node;
-  jsx_parseExpressionContainer(): acorn.Node;
-  jsx_parseAttribute(): acorn.Node;
-  jsx_parseOpeningElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
-  jsx_parseClosingElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
-  jsx_parseElementAt(startPos: number, startLoc?: acorn.SourceLocation): acorn.Node;
-  jsx_parseText(): acorn.Node;
-  jsx_parseElement(): acorn.Node;
-}
-
-export default jsx;
+export = jsx;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,23 @@
 import * as acorn from 'acorn';
 
-declare function jsx(options?: Options): (BaseParser: typeof acorn.Parser) => AcornJsxParser;
+type tokTypes = typeof acorn.tokTypes;
 
 export interface Options {
   allowNamespacedObjects?: boolean;
   allowNamespaces?: boolean;
 }
 
-export const tokTypes: {
+export interface TokTypes extends tokTypes {
   jsxName: acorn.TokenType,
   jsxText: acorn.TokenType,
   jsxTagEnd: acorn.TokenType,
   jsxTagStart: acorn.TokenType
-} & typeof acorn.tokTypes;
+}
+
+declare const jsx: {
+  tokTypes: TokTypes;
+  (options?: acorn.Options): (BaseParser: typeof acorn.Parser) => AcornJsxParser
+}
 
 export type TokContexts = {
   tc_oTag: acorn.TokContext,
@@ -27,7 +32,7 @@ type P = typeof acorn.Parser;
 //   `IAcornJsxParser` here)
 export interface AcornJsxParser extends Pick<P, keyof P> {
   readonly acornJsx: {
-    tokTypes: typeof tokTypes;
+    tokTypes: TokTypes;
     tokContexts: TokContexts
   };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as acorn from 'acorn';
 
-declare function jsx(options?: jsx.Options): (BaseParser: typeof acorn.Parser) => typeof AcornJsxParser;
+declare function jsx(options?: jsx.Options): (BaseParser: typeof acorn.Parser) => AcornJsxParser;
 
 export interface Options {
   allowNamespacedObjects?: boolean;
@@ -20,12 +20,21 @@ export type TokContexts = {
   tc_expr: acorn.TokContext
 };
 
-export class AcornJsxParser extends acorn.Parser {
-  static readonly acornJsx: {
+type P = typeof acorn.Parser;
+
+// We pick (statics) from acorn rather than plain extending to avoid complaint
+//   about base constructors needing the same return type (i.e., we return
+//   `IAcornJsxParser` here)
+export interface AcornJsxParser extends Pick<P, keyof P> {
+  readonly acornJsx: {
     tokTypes: typeof tokTypes;
     tokContexts: TokContexts
   };
 
+  new (options: acorn.Options, input: string, startPos?: number): IAcornJsxParser;
+}
+
+export interface IAcornJsxParser extends acorn.Parser {
   jsx_readToken(): string;
   jsx_readNewLine(normalizeCRLF: boolean): void;
   jsx_readString(quote: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,26 @@
-import { Parser } from 'acorn' 
+import acorn from 'acorn';
 
-declare const jsx: (options?: jsx.Options) => (BaseParser: typeof Parser) => typeof Parser;
+export const jsx: (options?: jsx.Options) => (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
 
-declare namespace jsx {
-  interface Options {
-    allowNamespacedObjects?: boolean;
-    allowNamespaces?: boolean;
-  }
+export interface Options {
+  allowNamespacedObjects?: boolean;
+  allowNamespaces?: boolean;
 }
 
-export = jsx;
+export const tokTypes: {
+    jsxName: acorn.TokenType,
+    jsxText: acorn.TokenType,
+    jsxTagEnd: acorn.TokenType,
+    jsxTagStart: acorn.TokenType
+} & typeof acorn.tokTypes;
+
+export class AcornJsxParser extends acorn.Parser {
+  static readonly acornJsx: {
+    tokTypes: typeof tokTypes
+  };
+
+  jsx_readString(quote: number): void;
+}
+
+export as namespace jsx;
+export default jsx;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import acorn from 'acorn';
 
-export const jsx: (options?: jsx.Options) => (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
+export const jsx: (options?: jsx.Options) => (BaseParser: typeof acorn.Parser) => typeof AcornJsxParser
 
 export interface Options {
   allowNamespacedObjects?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,14 @@
 import * as acorn from 'acorn';
 
+interface TokTypes extends AcornTokTypes {
+  jsxName: acorn.TokenType,
+  jsxText: acorn.TokenType,
+  jsxTagEnd: acorn.TokenType,
+  jsxTagStart: acorn.TokenType
+}
+
 declare const jsx: {
-  tokTypes: typeof acorn.tokTypes;
+  tokTypes: TokTypes;
   (options?: jsx.Options): (BaseParser: typeof acorn.Parser) => jsx.AcornJsxParserCtor
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as acorn from 'acorn';
 
-interface TokTypes extends AcornTokTypes {
+interface JsxTokTypes extends AcornTokTypes {
   jsxName: acorn.TokenType,
   jsxText: acorn.TokenType,
   jsxTagEnd: acorn.TokenType,
@@ -8,7 +8,7 @@ interface TokTypes extends AcornTokTypes {
 }
 
 declare const jsx: {
-  tokTypes: TokTypes;
+  tokTypes: JsxTokTypes;
   (options?: jsx.Options): (BaseParser: typeof acorn.Parser) => jsx.AcornJsxParserCtor
 }
 
@@ -16,12 +16,7 @@ type AcornTokTypes = typeof acorn.tokTypes;
 
 declare namespace jsx {
 
-  interface TokTypes extends AcornTokTypes {
-    jsxName: acorn.TokenType,
-    jsxText: acorn.TokenType,
-    jsxTagEnd: acorn.TokenType,
-    jsxTagStart: acorn.TokenType
-  }
+  type TokTypes = JsxTokTypes
 
   interface Options {
     allowNamespacedObjects?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as acorn from 'acorn';
 
-export const jsx: (options?: jsx.Options) => (BaseParser: typeof acorn.Parser) => typeof AcornJsxParser
+declare function jsx(options?: jsx.Options): (BaseParser: typeof acorn.Parser) => typeof AcornJsxParser;
 
 export interface Options {
   allowNamespacedObjects?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as acorn from 'acorn';
 
-declare function jsx(options?: jsx.Options): (BaseParser: typeof acorn.Parser) => AcornJsxParser;
+declare function jsx(options?: Options): (BaseParser: typeof acorn.Parser) => AcornJsxParser;
 
 export interface Options {
   allowNamespacedObjects?: boolean;


### PR DESCRIPTION
As explained at https://github.com/acornjs/acorn/pull/1104 , we're [looking](https://github.com/eslint/espree/issues/529#issuecomment-1012561247) to add type support to Espree (and other projects in the ESLint space), and in the case of your project, it looks like we could use this missing class and ESM import ability (especially since limiting ourselves to basic JSDoc for the TS declaration file generation makes it more useful not to have to reimplement types ourselves).

I'm pretty new to using TypeScript, so hope I've gotten things done all right. It seems I needed to remove the `export = jsx` and instead use `export default jsx;` to support ESM, but hopefully someone more competent in TS can give it a good look.

Also, the PR doesn't cover all methods or properties, but I hope this will at least improve things (and at least meets our immediate needs).

Best wishes...