### PR TITLE
feat: add `TokContext` as type (now that not exported as type from acorn)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,14 @@
 import * as acorn from 'acorn';
 
+declare class TokContext {
+  constructor(
+    token: string,
+    isExpr: boolean,
+    preserveSpace: boolean,
+    override?: (parser: any) => void
+  )
+}
+
 interface JsxTokTypes extends AcornTokTypes {
   jsxName: acorn.TokenType,
   jsxText: acorn.TokenType,
@@ -24,9 +33,9 @@ declare namespace jsx {
   }
 
   interface TokContexts {
-    tc_oTag: acorn.TokContext,
-    tc_cTag: acorn.TokContext,
-    tc_expr: acorn.TokContext
+    tc_oTag: TokContext,
+    tc_cTag: TokContext,
+    tc_expr: TokContext
   }
 
   // We pick (statics) from acorn rather than plain extending to avoid complaint

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
   },
   "license": "MIT",
   "scripts": {
+    "attw": "attw --pack",
     "test": "node test/run.js"
   },
   "peerDependencies": {
     "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "acorn": "^8.0.1"
+    "@arethetypeswrong/cli": "^0.18.2",
+    "acorn": "^8.15.0"
   }
 }


### PR DESCRIPTION
With your unreleased changes merged into `master`, there has since become a problem with some referenced types no longer being present in acorn.

In this PR, I made the parser type argument of `override` as `any` due to the complexity of the Parser class not being exported from acorn. See https://github.com/acornjs/acorn/issues/1260 and https://github.com/acornjs/acorn/issues/1404 .